### PR TITLE
PIP-85 Message.getSchema

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/InterceptorsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/InterceptorsTest.java
@@ -106,14 +106,14 @@ public class InterceptorsTest extends ProducerConsumerBase {
             @Override
             public boolean eligible(Message message) {
                 return SchemaType.STRING.equals(
-                        ((MessageImpl)message).getSchema().getSchemaInfo().getType());
+                        ((MessageImpl)message).getSchemaInternal().getSchemaInfo().getType());
             }
         };
         BaseInterceptor interceptor3 = new BaseInterceptor("int3") {
             @Override
             public boolean eligible(Message message) {
                 return SchemaType.INT32.equals(
-                        ((MessageImpl)message).getSchema().getSchemaInfo().getType());
+                        ((MessageImpl)message).getSchemaInternal().getSchemaInfo().getType());
             }
         };
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/SimpleSchemaTest.java
@@ -33,6 +33,7 @@ import static org.testng.Assert.fail;
 import org.apache.avro.reflect.ReflectData;
 import org.apache.avro.Schema.Parser;
 import org.apache.pulsar.client.impl.MessageImpl;
+import org.apache.pulsar.client.impl.schema.KeyValueSchema;
 import org.apache.pulsar.common.schema.LongSchemaVersion;
 import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.PulsarClientException.IncompatibleSchemaException;
@@ -527,8 +528,11 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
                 assertEquals(data.getValue().getField("i"), i);
                 MessageImpl impl = (MessageImpl) data;
 
-                org.apache.avro.Schema avroSchema = (org.apache.avro.Schema) impl.getSchema().getNativeSchema().get();
+                org.apache.avro.Schema avroSchema = (org.apache.avro.Schema) impl.getSchemaInternal().getNativeSchema().get();
                 assertNotNull(avroSchema);
+
+                org.apache.avro.Schema avroSchema2 = (org.apache.avro.Schema) data.getSchema().get().getNativeSchema().get();
+                assertNotNull(avroSchema2);
             }
 
         }
@@ -598,6 +602,9 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
                 assertNotNull(data.getSchemaVersion());
                 assertEquals(data.getValue().getKey().getField("i"), i * 100);
                 assertEquals(data.getValue().getValue().getField("i"), i * 1000);
+                KeyValueSchema keyValueSchema = (KeyValueSchema) data.getSchema().get();
+                assertNotNull(keyValueSchema.getKeySchema());
+                assertNotNull(keyValueSchema.getValueSchema());
             }
 
             // verify c2
@@ -606,6 +613,9 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
                 assertNotNull(data.getSchemaVersion());
                 assertEquals(data.getValue().getKey().i, i * 100);
                 assertEquals(data.getValue().getValue().i, i * 1000);
+                KeyValueSchema keyValueSchema = (KeyValueSchema) data.getSchema().get();
+                assertNotNull(keyValueSchema.getKeySchema());
+                assertNotNull(keyValueSchema.getValueSchema());
             }
 
             // verify c3
@@ -614,6 +624,9 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
                 assertNotNull(data.getSchemaVersion());
                 assertEquals(data.getValue().getKey().getField("i"), i * 100);
                 assertEquals(data.getValue().getValue().i, i * 1000);
+                KeyValueSchema keyValueSchema = (KeyValueSchema) data.getSchema().get();
+                assertNotNull(keyValueSchema.getKeySchema());
+                assertNotNull(keyValueSchema.getValueSchema());
             }
 
             // verify c4
@@ -622,6 +635,9 @@ public class SimpleSchemaTest extends ProducerConsumerBase {
                 assertNotNull(data.getSchemaVersion());
                 assertEquals(data.getValue().getKey().i, i * 100);
                 assertEquals(data.getValue().getValue().getField("i"), i * 1000);
+                KeyValueSchema keyValueSchema = (KeyValueSchema) data.getSchema().get();
+                assertNotNull(keyValueSchema.getKeySchema());
+                assertNotNull(keyValueSchema.getValueSchema());
             }
         }
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -55,6 +55,7 @@ import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.schema.GenericRecord;
 import org.apache.pulsar.client.api.schema.SchemaDefinition;
+import org.apache.pulsar.client.impl.schema.KeyValueSchema;
 import org.apache.pulsar.common.naming.TopicDomain;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.ClusterData;
@@ -131,10 +132,11 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
                         (false).withSupportSchemaVersioning(true).
                         withPojo(Schemas.PersonTwo.class).build()).getSchemaInfo());
 
-        admin.schemas().createSchema(fqtnTwo, Schema.AVRO(
+        Schema<Schemas.PersonTwo> personTwoSchema = Schema.AVRO(
                 SchemaDefinition.<Schemas.PersonTwo>builder().withAlwaysAllowNull
                         (false).withSupportSchemaVersioning(true).
-                        withPojo(Schemas.PersonTwo.class).build()).getSchemaInfo());
+                        withPojo(Schemas.PersonTwo.class).build());
+        admin.schemas().createSchema(fqtnTwo, personTwoSchema.getSchemaInfo());
 
         Producer<Schemas.PersonTwo> producer = pulsarClient.newProducer(Schema.AVRO(
                 SchemaDefinition.<Schemas.PersonTwo>builder().withAlwaysAllowNull
@@ -156,18 +158,40 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
                 .topic(fqtnOne, fqtnTwo)
                 .subscribe();
 
+        Consumer<GenericRecord> consumer2 = pulsarClient.newConsumer(Schema.AUTO_CONSUME())
+                .subscriptionName("test2")
+                .topic(fqtnOne, fqtnTwo)
+                .subscribe();
+
         producer.send(personTwo);
 
-        Schemas.PersonTwo personConsume = consumer.receive().getValue();
+        Message<Schemas.PersonTwo> message = consumer.receive();
+        Schemas.PersonTwo personConsume = message.getValue();
         assertEquals(personConsume.getName(), "Tom");
         assertEquals(personConsume.getId(), 1);
+        Schema<?> schema = message.getActualSchema().get();
+        log.info("the-schema {}", schema);
+        assertEquals(personTwoSchema.getSchemaInfo(), schema.getSchemaInfo());
+        org.apache.avro.Schema nativeSchema = (org.apache.avro.Schema) schema.getNativeSchema().get();
+        log.info("nativeSchema-schema {}", nativeSchema);
+        assertNotNull(nativeSchema);
+
+        // verify that with AUTO_CONSUME we can access the original schema
+        // and the Native AVRO schema
+        Message<?> message2 = consumer2.receive();
+        Schema<?> schema2 = message2.getActualSchema().get();
+        log.info("the-schema {}", schema2);
+        assertEquals(personTwoSchema.getSchemaInfo(), schema2.getSchemaInfo());
+        org.apache.avro.Schema nativeSchema2 = (org.apache.avro.Schema) schema.getNativeSchema().get();
+        log.info("nativeSchema-schema {}", nativeSchema2);
+        assertNotNull(nativeSchema2);
 
         producer.close();
         consumer.close();
     }
 
     @Test
-    public void testBytesSchemaDeserialize() throws Exception {
+    public void testJSONSchemaDeserialize() throws Exception {
         final String tenant = PUBLIC_TENANT;
         final String namespace = "test-namespace-" + randomName(16);
         final String topicName = "test-bytes-schema";
@@ -213,6 +237,12 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         assertEquals(message.getValue().getField("address").getClass(),
                 message1.getValue().getAddress().getClass());
 
+        Schema<?> schema = message.getActualSchema().get();
+        Schema<?> schema1 = message1.getActualSchema().get();
+        log.info("schema {}", schema);
+        log.info("schema1 {}", schema1);
+        assertEquals(schema.getSchemaInfo(), schema1.getSchemaInfo());
+
         producer.close();
         consumer.close();
         consumer1.close();
@@ -256,12 +286,14 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         producer.send("foo");
 
         Message<String> message = consumer.receive();
-        Message<GenericRecord> message3 = consumer2.receive();
+        Message<GenericRecord> message2 = consumer2.receive();
+        assertEquals(SchemaType.STRING, message.getActualSchema().get().getSchemaInfo().getType());
+        assertEquals(SchemaType.STRING, message2.getActualSchema().get().getSchemaInfo().getType());
 
         assertEquals("foo", message.getValue());
-        assertEquals(message3.getValue().getClass().getName(), "org.apache.pulsar.client.impl.schema.GenericObjectWrapper");
-        assertEquals(SchemaType.STRING, message3.getValue().getSchemaType());
-        assertEquals("foo", message3.getValue().getNativeObject());
+        assertEquals(message2.getValue().getClass().getName(), "org.apache.pulsar.client.impl.schema.GenericObjectWrapper");
+        assertEquals(SchemaType.STRING, message2.getValue().getSchemaType());
+        assertEquals("foo", message2.getValue().getNativeObject());
 
         producer.close();
         consumer.close();
@@ -324,12 +356,14 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         producer.send("foo".getBytes(StandardCharsets.UTF_8));
 
         Message<byte[]> message = consumer.receive();
-        Message<GenericRecord> message3 = consumer2.receive();
+        Message<GenericRecord> message2 = consumer2.receive();
+        assertFalse(message.getActualSchema().isPresent());
+        assertFalse(message2.getActualSchema().isPresent());
 
         assertEquals("foo".getBytes(StandardCharsets.UTF_8), message.getValue());
-        assertEquals(message3.getValue().getClass().getName(), "org.apache.pulsar.client.impl.schema.GenericObjectWrapper");
-        assertEquals(SchemaType.BYTES, message3.getValue().getSchemaType());
-        assertEquals("foo".getBytes(StandardCharsets.UTF_8), message3.getValue().getNativeObject());
+        assertEquals(message2.getValue().getClass().getName(), "org.apache.pulsar.client.impl.schema.GenericObjectWrapper");
+        assertEquals(SchemaType.BYTES, message2.getValue().getSchemaType());
+        assertEquals("foo".getBytes(StandardCharsets.UTF_8), message2.getValue().getNativeObject());
 
         producer.close();
         consumer.close();
@@ -447,6 +481,12 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         Message<KeyValue<Schemas.PersonOne, Schemas.PersonTwo>> message = consumer.receive();
         Message<GenericRecord> message2 = consumer2.receive();
         assertEquals(message.getValue(), message2.getValue().getNativeObject());
+
+        Schema<?> schema = message.getActualSchema().get();
+        Schema<?> schemaFromGenericRecord = message.getActualSchema().get();
+        KeyValueSchema keyValueSchema = (KeyValueSchema) schema;
+        KeyValueSchema keyValueSchemaFromGenericRecord = (KeyValueSchema) schemaFromGenericRecord;
+        assertEquals(keyValueSchema.getSchemaInfo(), keyValueSchemaFromGenericRecord.getSchemaInfo());
 
         if (keyValueEncodingType == KeyValueEncodingType.SEPARATED) {
             // with "SEPARATED encoding the routing key is the key of the KeyValue

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -169,7 +169,7 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         Schemas.PersonTwo personConsume = message.getValue();
         assertEquals(personConsume.getName(), "Tom");
         assertEquals(personConsume.getId(), 1);
-        Schema<?> schema = message.getActualSchema().get();
+        Schema<?> schema = message.getSchema().get();
         log.info("the-schema {}", schema);
         assertEquals(personTwoSchema.getSchemaInfo(), schema.getSchemaInfo());
         org.apache.avro.Schema nativeSchema = (org.apache.avro.Schema) schema.getNativeSchema().get();
@@ -179,7 +179,7 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         // verify that with AUTO_CONSUME we can access the original schema
         // and the Native AVRO schema
         Message<?> message2 = consumer2.receive();
-        Schema<?> schema2 = message2.getActualSchema().get();
+        Schema<?> schema2 = message2.getSchema().get();
         log.info("the-schema {}", schema2);
         assertEquals(personTwoSchema.getSchemaInfo(), schema2.getSchemaInfo());
         org.apache.avro.Schema nativeSchema2 = (org.apache.avro.Schema) schema.getNativeSchema().get();
@@ -237,8 +237,8 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         assertEquals(message.getValue().getField("address").getClass(),
                 message1.getValue().getAddress().getClass());
 
-        Schema<?> schema = message.getActualSchema().get();
-        Schema<?> schema1 = message1.getActualSchema().get();
+        Schema<?> schema = message.getSchema().get();
+        Schema<?> schema1 = message1.getSchema().get();
         log.info("schema {}", schema);
         log.info("schema1 {}", schema1);
         assertEquals(schema.getSchemaInfo(), schema1.getSchemaInfo());
@@ -287,8 +287,8 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
 
         Message<String> message = consumer.receive();
         Message<GenericRecord> message2 = consumer2.receive();
-        assertEquals(SchemaType.STRING, message.getActualSchema().get().getSchemaInfo().getType());
-        assertEquals(SchemaType.STRING, message2.getActualSchema().get().getSchemaInfo().getType());
+        assertEquals(SchemaType.STRING, message.getSchema().get().getSchemaInfo().getType());
+        assertEquals(SchemaType.STRING, message2.getSchema().get().getSchemaInfo().getType());
 
         assertEquals("foo", message.getValue());
         assertEquals(message2.getValue().getClass().getName(), "org.apache.pulsar.client.impl.schema.GenericObjectWrapper");
@@ -357,8 +357,8 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
 
         Message<byte[]> message = consumer.receive();
         Message<GenericRecord> message2 = consumer2.receive();
-        assertFalse(message.getActualSchema().isPresent());
-        assertFalse(message2.getActualSchema().isPresent());
+        assertFalse(message.getSchema().isPresent());
+        assertFalse(message2.getSchema().isPresent());
 
         assertEquals("foo".getBytes(StandardCharsets.UTF_8), message.getValue());
         assertEquals(message2.getValue().getClass().getName(), "org.apache.pulsar.client.impl.schema.GenericObjectWrapper");
@@ -482,8 +482,8 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         Message<GenericRecord> message2 = consumer2.receive();
         assertEquals(message.getValue(), message2.getValue().getNativeObject());
 
-        Schema<?> schema = message.getActualSchema().get();
-        Schema<?> schemaFromGenericRecord = message.getActualSchema().get();
+        Schema<?> schema = message.getSchema().get();
+        Schema<?> schemaFromGenericRecord = message.getSchema().get();
         KeyValueSchema keyValueSchema = (KeyValueSchema) schema;
         KeyValueSchema keyValueSchemaFromGenericRecord = (KeyValueSchema) schemaFromGenericRecord;
         assertEquals(keyValueSchema.getSchemaInfo(), keyValueSchemaFromGenericRecord.getSchemaInfo());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/schema/SchemaTest.java
@@ -460,9 +460,12 @@ public class SchemaTest extends MockedPulsarServiceBaseTest {
         if (schema == SchemaType.BYTES) {
             assertEquals(schema, message.getSchema().get().getSchemaInfo().getType());
             assertEquals(schema, message2.getSchema().get().getSchemaInfo().getType());
+        } else if (schema == SchemaType.NONE) {
+            // schema NONE is always reported as BYTES
+            assertEquals(SchemaType.BYTES, message.getSchema().get().getSchemaInfo().getType());
+            assertEquals(SchemaType.BYTES, message2.getSchema().get().getSchemaInfo().getType());
         } else {
-            assertFalse(message.getSchema().isPresent());
-            assertEquals(schema, message2.getSchema().get().getSchemaInfo().getType());
+            fail();
         }
 
         assertEquals("foo".getBytes(StandardCharsets.UTF_8), message.getValue());

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Message.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Message.java
@@ -209,6 +209,19 @@ public interface Message<T> {
     byte[] getSchemaVersion();
 
     /**
+     * Get the schema associated to the message.
+     * Please note that this schema is usually equal to the Schema you passed
+     * during the construction of the Consumer or the Reader.
+     * But if you are consuming the topic using the GenericObject interface
+     * this method will return the schema associated with the message.
+     * @return The schema used to decode the payload of message.
+     * @see Schema#AUTO_CONSUME()
+     */
+    default Optional<Schema<?>> getActualSchema() {
+        return Optional.<>empty();
+    }
+
+    /**
      * Check whether the message is replicated from other cluster.
      *
      * @since 2.4.0

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Message.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Message.java
@@ -217,7 +217,7 @@ public interface Message<T> {
      * @return The schema used to decode the payload of message.
      * @see Schema#AUTO_CONSUME()
      */
-    default Optional<Schema<?>> getActualSchema() {
+    default Optional<Schema<?>> getSchema() {
         return Optional.empty();
     }
 

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Message.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Message.java
@@ -218,7 +218,7 @@ public interface Message<T> {
      * @see Schema#AUTO_CONSUME()
      */
     default Optional<Schema<?>> getActualSchema() {
-        return Optional.<>empty();
+        return Optional.empty();
     }
 
     /**

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Schema.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Schema.java
@@ -27,6 +27,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Date;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.apache.pulsar.client.api.schema.GenericRecord;
@@ -94,11 +95,18 @@ public interface Schema<T> extends Cloneable{
 
     /**
      * Return an instance of this schema at the given version.
-     * @param schemaVersion
+     * @param schemaVersion the version
      * @return the schema at that specific version
+     * @throws SchemaSerializationException in case of unknown schema version
+     * @throws NullPointerException in case of null schemaVersion
      */
-    default Schema<?> atSchemaVersion(byte[] schemaVersion) {
-        return this;
+    default Schema<?> atSchemaVersion(byte[] schemaVersion) throws SchemaSerializationException {
+        Objects.requireNonNull(schemaVersion);
+        if (!supportSchemaVersioning()) {
+            return this;
+        } else {
+            throw new SchemaSerializationException("Not implemented for " + this.getClass());
+        }
     }
 
     default void setSchemaInfoProvider(SchemaInfoProvider schemaInfoProvider) {

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Schema.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/Schema.java
@@ -92,6 +92,15 @@ public interface Schema<T> extends Cloneable{
         return false;
     }
 
+    /**
+     * Return an instance of this schema at the given version.
+     * @param schemaVersion
+     * @return the schema at that specific version
+     */
+    default Schema<?> atSchemaVersion(byte[] schemaVersion) {
+        return this;
+    }
+
     default void setSchemaInfoProvider(SchemaInfoProvider schemaInfoProvider) {
     }
 

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/schema/SchemaReader.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/schema/SchemaReader.java
@@ -19,6 +19,8 @@
 package org.apache.pulsar.client.api.schema;
 
 import java.io.InputStream;
+import java.util.Optional;
+
 import org.apache.pulsar.common.classification.InterfaceAudience;
 import org.apache.pulsar.common.classification.InterfaceStability;
 
@@ -87,7 +89,11 @@ public interface SchemaReader<T> {
     default void setSchemaInfoProvider(SchemaInfoProvider schemaInfoProvider) {
     }
 
-    default Object getNativeSchema() {
-        return null;
+    /**
+     * Returns the underling Schema if possible
+     * @return the schema, or an empty Optional if it is not possible to access it
+     */
+    default Optional<Object> getNativeSchema() {
+        return Optional.empty();
     }
 }

--- a/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/schema/SchemaReader.java
+++ b/pulsar-client-api/src/main/java/org/apache/pulsar/client/api/schema/SchemaReader.java
@@ -86,4 +86,8 @@ public interface SchemaReader<T> {
      */
     default void setSchemaInfoProvider(SchemaInfoProvider schemaInfoProvider) {
     }
+
+    default Object getNativeSchema() {
+        return null;
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -395,7 +395,7 @@ public class MessageImpl<T> implements Message<T> {
             return Optional.empty();
         }
         byte[] schemaVersion = getSchemaVersion();
-        return schema.atSchemaVersion(schemaVersion);
+        return Optional.of(schema.atSchemaVersion(schemaVersion));
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -389,6 +389,16 @@ public class MessageImpl<T> implements Message<T> {
     }
 
     @Override
+    public Optional<Schema<?>> getActualSchema() {
+        ensureSchemaIsLoaded();
+        if (schema == null) {
+            return Optional.empty();
+        }
+        byte[] schemaVersion = getSchemaVersion();
+        return schema.atSchemaVersion(schemaVersion);
+    }
+
+    @Override
     public byte[] getSchemaVersion() {
         if (msgMetadata.hasSchemaVersion()) {
             return msgMetadata.getSchemaVersion();
@@ -397,10 +407,13 @@ public class MessageImpl<T> implements Message<T> {
         }
     }
 
-    private SchemaInfo getSchemaInfo() {
+    private void ensureSchemaIsLoaded() {
         if (schema instanceof AutoConsumeSchema) {
             ((AutoConsumeSchema) schema).fetchSchemaIfNeeded();
         }
+    }
+    private SchemaInfo getSchemaInfo() {
+        ensureSchemaIsLoaded();
         return schema.getSchemaInfo();
     }
 

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/MessageImpl.java
@@ -384,12 +384,12 @@ public class MessageImpl<T> implements Message<T> {
         return payload.readableBytes();
     }
 
-    public Schema<T> getSchema() {
+    public Schema<T> getSchemaInternal() {
         return this.schema;
     }
 
     @Override
-    public Optional<Schema<?>> getActualSchema() {
+    public Optional<Schema<?>> getSchema() {
         ensureSchemaIsLoaded();
         if (schema == null) {
             return Optional.empty();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ProducerImpl.java
@@ -572,7 +572,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
 
     private boolean populateMessageSchema(MessageImpl msg, SendCallback callback) {
         MessageMetadata msgMetadataBuilder = msg.getMessageBuilder();
-        if (msg.getSchema() == schema) {
+        if (msg.getSchemaInternal() == schema) {
             schemaVersion.ifPresent(v -> msgMetadataBuilder.setSchemaVersion(v));
             msg.setSchemaState(MessageImpl.SchemaState.Ready);
             return true;
@@ -584,7 +584,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
             completeCallbackAndReleaseSemaphore(msg.getUncompressedSize(), callback, e);
             return false;
         }
-        SchemaHash schemaHash = SchemaHash.of(msg.getSchema());
+        SchemaHash schemaHash = SchemaHash.of(msg.getSchemaInternal());
         byte[] schemaVersion = schemaCache.get(schemaHash);
         if (schemaVersion != null) {
             msgMetadataBuilder.setSchemaVersion(schemaVersion);
@@ -594,7 +594,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
     }
 
     private boolean rePopulateMessageSchema(MessageImpl msg) {
-        SchemaHash schemaHash = SchemaHash.of(msg.getSchema());
+        SchemaHash schemaHash = SchemaHash.of(msg.getSchemaInternal());
         byte[] schemaVersion = schemaCache.get(schemaHash);
         if (schemaVersion == null) {
             return false;
@@ -608,7 +608,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
         if (!changeToRegisteringSchemaState()) {
             return;
         }
-        SchemaInfo schemaInfo = Optional.ofNullable(msg.getSchema())
+        SchemaInfo schemaInfo = Optional.ofNullable(msg.getSchemaInternal())
                                         .map(Schema::getSchemaInfo)
                                         .filter(si -> si.getType().getValue() > 0)
                                         .orElse(Schema.BYTES.getSchemaInfo());
@@ -622,7 +622,7 @@ public class ProducerImpl<T> extends ProducerBase<T> implements TimerTask, Conne
                 }
             } else {
                 log.warn("[{}] [{}] GetOrCreateSchema succeed", topic, producerName);
-                SchemaHash schemaHash = SchemaHash.of(msg.getSchema());
+                SchemaHash schemaHash = SchemaHash.of(msg.getSchemaInternal());
                 schemaCache.putIfAbsent(schemaHash, v);
                 msg.getMessageBuilder().setSchemaVersion(v);
                 msg.setSchemaState(MessageImpl.SchemaState.Ready);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageImpl.java
@@ -182,17 +182,17 @@ public class TopicMessageImpl<T> implements Message<T> {
         return msg;
     }
 
-    public Schema<T> getSchema() {
+    public Schema<T> getSchemaInternal() {
         if (this.msg instanceof MessageImpl) {
             MessageImpl message = (MessageImpl) this.msg;
-            return message.getSchema();
+            return message.getSchemaInternal();
         }
         return null;
     }
 
     @Override
-    public Optional<Schema<?>> getActualSchema() {
-        return msg.getActualSchema();
+    public Optional<Schema<?>> getSchema() {
+        return msg.getSchema();
     }
 
     @Override

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/TopicMessageImpl.java
@@ -191,6 +191,11 @@ public class TopicMessageImpl<T> implements Message<T> {
     }
 
     @Override
+    public Optional<Schema<?>> getActualSchema() {
+        return msg.getActualSchema();
+    }
+
+    @Override
     public void release() {
         msg.release();
     }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AbstractStructSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AbstractStructSchema.java
@@ -80,6 +80,31 @@ public abstract class AbstractStructSchema<T> extends AbstractSchema<T> {
         if (reader != null) {
             this.reader.setSchemaInfoProvider(schemaInfoProvider);
         }
+        this.schemaInfoProvider = schemaInfoProvider;
+    }
+
+    public Schema<?> atSchemaVersion(byte[] schemaVersion) {
+        if (schemaInfoProvider == null) {
+            throw new IllegalStateException("SchemaInfoProvider is not initialized");
+        }
+        SchemaInfo schemaInfo = schemaInfoProvider.getSchemaByVersion(schemaVersion).get();
+        AbstractStructSchema copy =  new AbstractStructSchema(schemaInfo) {
+
+            @Override
+            public T decode(byte[] bytes) {
+                return decode(bytes, schemaVersion);
+            }
+
+            @Override
+            public T decode(ByteBuf byteBuf) {
+                return decode(byteBuf, schemaVersion);
+            }
+
+        };
+        copy.writer = writer;
+        copy.reader = reader;
+        copy.schemaInfoProvider = schemaInfoProvider;
+        return copy;
     }
 
     protected void setWriter(SchemaWriter<T> writer) {

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AbstractStructSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AbstractStructSchema.java
@@ -140,7 +140,7 @@ public abstract class AbstractStructSchema<T> extends AbstractSchema<T> {
                 AbstractMultiVersionReader abstractMultiVersionReader = (AbstractMultiVersionReader) reader;
                 try {
                     SchemaReader schemaReader = abstractMultiVersionReader.getSchemaReader(schemaVersion);
-                    return Optional.ofNullable(schemaReader.getNativeSchema());
+                    return schemaReader.getNativeSchema();
                 } catch (ExecutionException err) {
                     throw new RuntimeException(err.getCause());
                 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/AutoConsumeSchema.java
@@ -79,6 +79,17 @@ public class AutoConsumeSchema implements Schema<GenericRecord> {
     }
 
     @Override
+    public Schema<?> atSchemaVersion(byte[] schemaVersion) {
+        fetchSchemaIfNeeded();
+        ensureSchemaInitialized();
+        if (schema.supportSchemaVersioning()) {
+            return schema.atSchemaVersion(schemaVersion);
+        } else {
+            return schema;
+        }
+    }
+
+    @Override
     public GenericRecord decode(byte[] bytes, byte[] schemaVersion) {
         fetchSchemaIfNeeded();
         ensureSchemaInitialized();

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/KeyValueSchema.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/KeyValueSchema.java
@@ -258,4 +258,11 @@ public class KeyValueSchema<K, V> implements Schema<KeyValue<K, V>> {
     public String toString() {
         return "KeyValueSchema(" + keyValueEncodingType + "," + keySchema + "," + valueSchema + ")";
     }
+
+    @Override
+    public Schema<?> atSchemaVersion(byte[] schemaVersion) throws SchemaSerializationException {
+        // KetValue schema supports versioning because
+        // the inner Schema for key and value may support schema versioning
+        return this;
+    }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroReader.java
@@ -36,6 +36,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 
@@ -118,8 +119,8 @@ public class GenericAvroReader implements SchemaReader<GenericRecord> {
     }
 
     @Override
-    public Object getNativeSchema() {
-        return schema;
+    public Optional<Object> getNativeSchema() {
+        return Optional.of(schema);
     }
 
     private static final Logger log = LoggerFactory.getLogger(GenericAvroReader.class);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericAvroReader.java
@@ -117,5 +117,10 @@ public class GenericAvroReader implements SchemaReader<GenericRecord> {
         return offset;
     }
 
+    @Override
+    public Object getNativeSchema() {
+        return schema;
+    }
+
     private static final Logger log = LoggerFactory.getLogger(GenericAvroReader.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericProtobufNativeReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericProtobufNativeReader.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class GenericProtobufNativeReader implements SchemaReader<GenericRecord> {
@@ -80,8 +81,8 @@ public class GenericProtobufNativeReader implements SchemaReader<GenericRecord> 
     }
 
     @Override
-    public Object getNativeSchema() {
-        return descriptor;
+    public Optional<Object> getNativeSchema() {
+        return Optional.of(descriptor);
     }
 
     private static final Logger log = LoggerFactory.getLogger(GenericProtobufNativeReader.class);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericProtobufNativeReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericProtobufNativeReader.java
@@ -79,5 +79,10 @@ public class GenericProtobufNativeReader implements SchemaReader<GenericRecord> 
         }
     }
 
+    @Override
+    public Object getNativeSchema() {
+        return descriptor;
+    }
+
     private static final Logger log = LoggerFactory.getLogger(GenericProtobufNativeReader.class);
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericSchemaImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericSchemaImpl.java
@@ -51,11 +51,6 @@ public abstract class GenericSchemaImpl extends AvroBaseStructSchema<GenericReco
         return fields;
     }
 
-    @Override
-    protected Optional<Object> buildNativeSchema(SchemaInfo schemaInfo) {
-        return of(schemaInfo, true).getNativeSchema();
-    }
-
     /**
      * Create a generic schema out of a <tt>SchemaInfo</tt>.
      *  warning : we suggest migrate GenericSchemaImpl.of() to  <GenericSchema Implementor>.of() method (e.g. GenericJsonSchema 、GenericAvroSchema )

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericSchemaImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/generic/GenericSchemaImpl.java
@@ -25,6 +25,7 @@ import org.apache.pulsar.client.impl.schema.AvroBaseStructSchema;
 import org.apache.pulsar.common.schema.SchemaInfo;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -48,6 +49,11 @@ public abstract class GenericSchemaImpl extends AvroBaseStructSchema<GenericReco
     @Override
     public List<Field> getFields() {
         return fields;
+    }
+
+    @Override
+    protected Optional<Object> buildNativeSchema(SchemaInfo schemaInfo) {
+        return of(schemaInfo, true).getNativeSchema();
     }
 
     /**

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/AbstractMultiVersionReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/AbstractMultiVersionReader.java
@@ -71,7 +71,7 @@ public abstract class AbstractMultiVersionReader<T> implements SchemaReader<T> {
     public T read(InputStream inputStream, byte[] schemaVersion) {
         try {
             return schemaVersion == null ? read(inputStream) :
-                    readerCache.get(BytesSchemaVersion.of(schemaVersion)).read(inputStream);
+                    getSchemaReader(schemaVersion).read(inputStream);
         } catch (ExecutionException e) {
             LOG.error("Can't get generic schema for topic {} schema version {}",
                     schemaInfoProvider.getTopicName(), Hex.encodeHexString(schemaVersion), e);
@@ -79,11 +79,15 @@ public abstract class AbstractMultiVersionReader<T> implements SchemaReader<T> {
         }
     }
 
+    public SchemaReader<T> getSchemaReader(byte[] schemaVersion) throws ExecutionException {
+        return readerCache.get(BytesSchemaVersion.of(schemaVersion));
+    }
+
     @Override
     public T read(byte[] bytes, byte[] schemaVersion) {
         try {
             return schemaVersion == null ? read(bytes) :
-                    readerCache.get(BytesSchemaVersion.of(schemaVersion)).read(bytes);
+                    getSchemaReader(schemaVersion).read(bytes);
         } catch (ExecutionException | AvroTypeException e) {
             if (e instanceof AvroTypeException) {
                 throw new SchemaSerializationException(e);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/AvroReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/AvroReader.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Optional;
 
 public class AvroReader<T> implements SchemaReader<T> {
 
@@ -103,8 +104,8 @@ public class AvroReader<T> implements SchemaReader<T> {
     }
 
     @Override
-    public Object getNativeSchema() {
-        return schema;
+    public Optional<Object> getNativeSchema() {
+        return Optional.of(schema);
     }
 
     private static final Logger log = LoggerFactory.getLogger(AvroReader.class);

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/AvroReader.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/schema/reader/AvroReader.java
@@ -38,12 +38,15 @@ public class AvroReader<T> implements SchemaReader<T> {
     private ReflectDatumReader<T> reader;
     private static final ThreadLocal<BinaryDecoder> decoders =
             new ThreadLocal<>();
+    private final Schema schema;
 
     public AvroReader(Schema schema) {
         this.reader = new ReflectDatumReader<>(schema);
+        this.schema = schema;
     }
 
     public AvroReader(Schema schema, ClassLoader classLoader, boolean jsr310ConversionEnabled) {
+        this.schema = schema;
         if (classLoader != null) {
             ReflectData reflectData = new ReflectData(classLoader);
             AvroSchema.addLogicalTypeConversions(reflectData, jsr310ConversionEnabled);
@@ -55,6 +58,7 @@ public class AvroReader<T> implements SchemaReader<T> {
 
     public AvroReader(Schema writerSchema, Schema readerSchema, ClassLoader classLoader,
         boolean jsr310ConversionEnabled) {
+        this.schema = readerSchema;
         if (classLoader != null) {
             ReflectData reflectData = new ReflectData(classLoader);
             AvroSchema.addLogicalTypeConversions(reflectData, jsr310ConversionEnabled);
@@ -96,6 +100,11 @@ public class AvroReader<T> implements SchemaReader<T> {
                 log.error("AvroReader close inputStream close error", e);
             }
         }
+    }
+
+    @Override
+    public Object getNativeSchema() {
+        return schema;
     }
 
     private static final Logger log = LoggerFactory.getLogger(AvroReader.class);

--- a/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
+++ b/pulsar-functions/instance/src/main/java/org/apache/pulsar/functions/source/PulsarSource.java
@@ -106,10 +106,10 @@ public abstract class PulsarSource<T> implements Source<T> {
         Schema<T> schema = null;
         if (message instanceof MessageImpl) {
             MessageImpl impl = (MessageImpl) message;
-            schema = impl.getSchema();
+            schema = impl.getSchemaInternal();
         } else if (message instanceof TopicMessageImpl) {
             TopicMessageImpl impl = (TopicMessageImpl) message;
-            schema = impl.getSchema();
+            schema = impl.getSchemaInternal();
         }
         return PulsarRecord.<T>builder()
                 .message(message)

--- a/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/PulsarSourceTest.java
+++ b/pulsar-functions/instance/src/test/java/org/apache/pulsar/functions/source/PulsarSourceTest.java
@@ -40,7 +40,6 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.ConsumerBuilder;
-import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
@@ -321,13 +320,13 @@ public class PulsarSourceTest {
         Consumer consumer = Mockito.mock(Consumer.class);
         MessageImpl messageImpl = Mockito.mock(MessageImpl.class);
         Schema schema = Mockito.mock(Schema.class);
-        Mockito.when(messageImpl.getSchema()).thenReturn(schema);
+        Mockito.when(messageImpl.getSchemaInternal()).thenReturn(schema);
         if (pulsarSource instanceof MultiConsumerPulsarSource) {
             ((MultiConsumerPulsarSource) pulsarSource).received(consumer, messageImpl);
         } else {
             Mockito.doReturn(messageImpl).when(((SingleConsumerPulsarSource) pulsarSource).getInputConsumer()).receive();
         }
-        Mockito.verify(messageImpl.getSchema(), Mockito.times(1));
+        Mockito.verify(messageImpl.getSchemaInternal(), Mockito.times(1));
         Record<GenericRecord> pushed = pulsarSource.read();
         assertSame(pushed.getSchema(), schema);
     }


### PR DESCRIPTION
- rename MessageImpl and TopicMessageImpl `getSchema` to `getSchemaInternal`
- introduce Optional<Schema<?>> Message.getSchema()
- introduce Schema.atSchemaVersion, that allows to get a Schema at a specific "version", this is needed for AutoConsumeSchema

The schema returned by Message.getSchema has these properties:
- SchemaInfo it what is stored on the Registry
- getNativeSchema returns the original AVRO Schema as expected
- it can be used for "decoding" payloads
- it cannot be used for "encoding" payloads

